### PR TITLE
Add Read the Docs configuration for documentation build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/build-customization.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.12"
+  commands:
+    - asdf plugin add uv
+    - asdf install uv latest
+    - asdf global uv latest
+    - uv sync --extra docs --frozen
+    - NO_COLOR=1 uv run mkdocs build --site-dir $READTHEDOCS_OUTPUT/html


### PR DESCRIPTION
Introduce a configuration file for building documentation on Read the Docs, specifying the environment and commands needed for the build process.