### PR TITLE
Simplify uv sync command in Read the Docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,5 +14,5 @@ build:
     - asdf plugin add uv
     - asdf install uv latest
     - asdf global uv latest
-    - uv sync --extra docs --frozen
+    - uv sync
     - NO_COLOR=1 uv run mkdocs build --site-dir $READTHEDOCS_OUTPUT/html


### PR DESCRIPTION
Remove unnecessary options from the uv sync command in the Read the Docs configuration for simplicity.