### PR TITLE
Add port mapping for service in Docker Compose configuration

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -7,4 +7,6 @@ services:
       - ./logs:/app/logs
     environment:
       - PYTHONUNBUFFERED=1
+    ports:
+      - "50051:50051"
     restart: unless-stopped


### PR DESCRIPTION
Include port mapping for the service to enable communication on port 50051.