### PR TITLE
Add calibrated_at field to device info response

### DIFF
--- a/config/device_topology.json
+++ b/config/device_topology.json
@@ -1,6 +1,6 @@
 {
-  "name": "test_device",
-  "device_id": "1",
+  "name": "qulacs",
+  "device_id": "qiqb",
   "qubits": [
     {
       "id": 0,

--- a/src/device_gateway/service.py
+++ b/src/device_gateway/service.py
@@ -119,6 +119,9 @@ class ServerImpl(qpu_pb2_grpc.QpuServiceServicer):
             logger.info("GetDeviceInfo is started.")
             response_parameters = self._config["device_info"]
             response_parameters["device_info"] = json.dumps(self.device_topology_json)
+            response_parameters["calibrated_at"] = json.dumps(
+                self.device_topology_json["calibrated_at"]
+            )
             device_info = qpu_pb2.DeviceInfo(**response_parameters)  # type: ignore[attr-defined]
             response = qpu_pb2.GetDeviceInfoResponse(  # type: ignore[attr-defined]
                 body=device_info


### PR DESCRIPTION
Introduce a new field, calibrated_at, in the device info response to provide additional calibration data. Update the device name and ID for consistency.