### PR TITLE
build(docker): add cmake and boost dependencies in Dockerfile.dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,15 +7,15 @@ WORKDIR /app
 
 # install tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential \
+  cmake \
   curl \
   git \
   iproute2 \
+  libboost-all-dev \
   procps \
   tar \
-  vim \
-  libboost-all-dev \
-  build-essential \
-  cmake && \
+  vim && \
   curl -L "https://github.com/fullstorydev/grpcurl/releases/download/v1.9.3/grpcurl_1.9.3_linux_x86_64.tar.gz" | tar -xz -C /usr/local/bin && \
   chmod +x /usr/local/bin/grpcurl && \
   apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,7 +12,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   iproute2 \
   procps \
   tar \
-  vim && \
+  vim \
+  libboost-all-dev \
+  build-essential \
+  cmake && \
   curl -L "https://github.com/fullstorydev/grpcurl/releases/download/v1.9.3/grpcurl_1.9.3_linux_x86_64.tar.gz" | tar -xz -C /usr/local/bin && \
   chmod +x /usr/local/bin/grpcurl && \
   apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
# 📃 Ticket

## ✍ Description

Some modifications were necessary to build Dockerfile.dev in my environment.

Environment:
- Machine:
  - Apple M2 MacBook Air
- Docker:
  - Client: 28.0.4
  - Server:
    - Docker Desktop: 4.40.0 (187762)
    - Engine: 28.0.4

## 📸 Test Result

## 🔗 Related PRs

