### PR TITLE
Update qubex dependency to v1.3.7rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,4 +55,4 @@ addopts = "--cov=src --cov-report=xml"
 pythonpath = ["src","src/device_gateway","src/device_gateway/qpu_interface","src/device_gateway/qpu_interface","src/device_gateway/qpu_interface/v2"]
 
 [tool.uv.sources]
-qubex = { git = "https://github.com/amachino/qubex.git", tag = "v1.3.4rc1" }
+qubex = { git = "https://github.com/amachino/qubex.git", tag = "v1.3.7rc1" }

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ dev = [
     { name = "python-json-logger", specifier = ">=2.0.7" },
     { name = "ruff", specifier = ">=0.11.0" },
 ]
-qubex = [{ name = "qubex", extras = ["backend"], git = "https://github.com/amachino/qubex.git?tag=v1.3.4rc1" }]
+qubex = [{ name = "qubex", extras = ["backend"], git = "https://github.com/amachino/qubex.git?tag=v1.3.7rc1" }]
 
 [[package]]
 name = "dill"
@@ -2489,8 +2489,8 @@ wheels = [
 
 [[package]]
 name = "qubecalib"
-version = "3.1.9"
-source = { git = "https://github.com/qiqb-osaka/qube-calib.git?rev=542c30b#542c30bfb268f7f2df0f7a072460eea13d381629" }
+version = "3.1.11rc1"
+source = { git = "https://github.com/qiqb-osaka/qube-calib.git?rev=3.1.11rc1#5697eadb0f54efc2918f2a74e9fc857c2359436e" }
 dependencies = [
     { name = "e7awgsw" },
     { name = "jupyter" },
@@ -2509,8 +2509,8 @@ dependencies = [
 
 [[package]]
 name = "qubex"
-version = "1.3.4rc1+44ff2d7"
-source = { git = "https://github.com/amachino/qubex.git?tag=v1.3.4rc1#44ff2d7bcdb84fbfbc92310b42cefe14a461bb1d" }
+version = "1.3.7rc1+12873a4"
+source = { git = "https://github.com/amachino/qubex.git?tag=v1.3.7rc1#12873a43ffc8e2aec956b2a47200d85689ccf5cf" }
 dependencies = [
     { name = "cma" },
     { name = "httpx" },


### PR DESCRIPTION
The commit updates the qubex package version from v1.3.4rc1 to v1.3.7rc1 in both pyproject.toml and uv.lock files. This also includes an automatic update of the qubecalib dependency to version 3.1.11rc1.

