### PR TITLE
Update QubexBackend readout calibration

### DIFF
--- a/src/device_gateway/service.py
+++ b/src/device_gateway/service.py
@@ -40,7 +40,6 @@ class ServerImpl(qpu_pb2_grpc.QpuServiceServicer):
             config: Configuration dictionary.
         """
         super().__init__()
-        self._execute_readout_calibration = True
         self._backend_manager = BackendPluginManager()
         self._initialize_backend(config)
         logger.info(f"ServerImpl initialized with backend: {self.backend_name}")


### PR DESCRIPTION
Moves readout calibration logic from service to backend class. Improves code organization by
keeping backend-specific calibration within the backend implementation.

