### PR TITLE
Fix typo in experiment linkup method

### DIFF
--- a/src/device_gateway/plugins/qubex/backend.py
+++ b/src/device_gateway/plugins/qubex/backend.py
@@ -30,7 +30,7 @@ class QubexBackend(BaseBackend):
             ),
         )
         logger.info(f"Qubex version: {get_package_version('qubex')}")
-        self._expeeriment.linkup()
+        self._experiment.linkup()
         logger.info("Qubex experiment linked up successfully")
 
     def _search_qubit_by_id(self, id):


### PR DESCRIPTION
Correct a typo in the method call for linking up the experiment.