### PR TITLE
Implement delay method in QubexCircuit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ name = "device-gateway"
 version = "1.0.0"
 description = "Device Gateway"
 license = "Apache-2.0"
-readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "grpcio>=1.70.0",
@@ -56,4 +55,4 @@ addopts = "--cov=src --cov-report=xml"
 pythonpath = ["src","src/device_gateway","src/device_gateway/qpu_interface","src/device_gateway/qpu_interface","src/device_gateway/qpu_interface/v2"]
 
 [tool.uv.sources]
-qubex = { git = "https://github.com/amachino/qubex.git", tag = "v1.3.8" }
+qubex = { git = "https://github.com/amachino/qubex.git", tag = "v1.4.0rc3" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,4 +55,4 @@ addopts = "--cov=src --cov-report=xml"
 pythonpath = ["src","src/device_gateway","src/device_gateway/qpu_interface","src/device_gateway/qpu_interface","src/device_gateway/qpu_interface/v2"]
 
 [tool.uv.sources]
-qubex = { git = "https://github.com/amachino/qubex.git", tag = "v1.4.0rc3" }
+qubex = { git = "https://github.com/amachino/qubex.git", tag = "v1.4.1b1" }

--- a/scripts/device_topology_generator.sh
+++ b/scripts/device_topology_generator.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-set -e
+set -a
+source .env
+set +a
+
+echo "$QDASH_API_URL"
 
 API_URL=${QDASH_API_URL:-http://localhost:6004/api}
 

--- a/scripts/qubex_config_downloader.sh
+++ b/scripts/qubex_config_downloader.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-set -e
+set -a
+source .env
+set +a
+
+echo "$QDASH_API_URL"
 
 API_URL=${QDASH_API_URL:-http://localhost:6004/api}
 

--- a/src/device_gateway/core/base_backend.py
+++ b/src/device_gateway/core/base_backend.py
@@ -84,6 +84,13 @@ class BaseBackend(metaclass=ABCMeta):
         Returns the device topology, e.g., {"qubits": [{"id": 0, "physical_id": 5}], "couplings": [{"control": 0, "target": 1}]}
         """
         return self.load_device_topology()
+    
+    @property
+    def physical_ids(self) -> list:
+        """
+        Returns a list of physical IDs of the qubits, e.g., [5, 7]
+        """
+        return [qubit["physical_id"] for qubit in self.device_topology["qubits"]]
 
     @property
     def device_status(self) -> dict:

--- a/src/device_gateway/core/gate_set.py
+++ b/src/device_gateway/core/gate_set.py
@@ -8,4 +8,5 @@ SUPPORTED_GATES = {
     "cx",  # CNOT gate
     "measure",
     "barrier",
+    "delay",
 }

--- a/src/device_gateway/plugins/qubex/backend.py
+++ b/src/device_gateway/plugins/qubex/backend.py
@@ -30,8 +30,6 @@ class QubexBackend(BaseBackend):
             ),
         )
         logger.info(f"Qubex version: {get_package_version('qubex')}")
-        self._experiment.linkup()
-        logger.info("Qubex experiment linked up successfully")
 
     def _search_qubit_by_id(self, id):
         for qubit in self.device_topology.get("qubits", []):
@@ -105,6 +103,8 @@ class QubexBackend(BaseBackend):
         The compiled_circuit is produced by the PulseSchedule class.
         """
         if self.is_active() and self._execute_readout_calibration:
+            self._experiment.connect()
+            logger.info("Qubex experiment connect successfully")
             logger.info("Performing readout calibration")
             self._readout_calibration()
             self._execute_readout_calibration = False

--- a/src/device_gateway/plugins/qubex/backend.py
+++ b/src/device_gateway/plugins/qubex/backend.py
@@ -22,7 +22,7 @@ class QubexBackend(BaseBackend):
         self._execute_readout_calibration = True
         self._experiment = Experiment(
             chip_id=os.getenv("CHIP_ID", "64Q"),
-            qubits=self.qubits,
+            qubits=self.physical_ids,
             config_dir=os.getenv("CONFIG_DIR", "/app/qubex_config"),
             params_dir=os.getenv("PARAMS_DIR", "/app/qubex_config"),
             calib_note_path=os.getenv(
@@ -30,6 +30,26 @@ class QubexBackend(BaseBackend):
             ),
         )
         logger.info(f"Qubex version: {get_package_version('qubex')}")
+
+    @property
+    def physical_map(self):
+        """
+        Returns the physical index to physical label mapping.
+        The mapping is in the format physical_map: {'qubits': {0: 'Q29', 1: 'Q30', 2: 'Q31'}, 'couplings': {(2, 0): ('Q31', 'Q29'), (2, 1): ('Q31', 'Q30')}}"}
+        """
+        device_topology = self.load_device_topology()
+        qubits = {
+            qubit["id"]: f"{self._experiment.get_qubit_label(int(qubit["physical_id"]))}"
+            for qubit in device_topology["qubits"]
+        }
+        couplings = {
+            (c["control"], c["target"]): (
+                qubits[c["control"]],
+                qubits[c["target"]],
+            )
+            for c in device_topology["couplings"]
+        }
+        return {"qubits": qubits, "couplings": couplings}
 
     def _search_qubit_by_id(self, id):
         for qubit in self.device_topology.get("qubits", []):
@@ -96,6 +116,7 @@ class QubexBackend(BaseBackend):
             mode="single",
             shots=shots,
             interval=DEFAULT_INTERVAL,
+            reset_awg_and_capunits = False,
         ).get_counts(targets=self.classical_registers)
 
     def execute(self, program: str, shots: int = 1024) -> tuple[dict, str]:


### PR DESCRIPTION
Introduce a delay method to the QubexCircuit class, allowing the application of a delay to specified qubits with a defined duration. Update imports accordingly to support this new functionality.