### PR TITLE
Enable AWG and capacitance unit reset during execution

### DIFF
--- a/src/device_gateway/plugins/qubex/backend.py
+++ b/src/device_gateway/plugins/qubex/backend.py
@@ -116,7 +116,7 @@ class QubexBackend(BaseBackend):
             mode="single",
             shots=shots,
             interval=DEFAULT_INTERVAL,
-            reset_awg_and_capunits = False,
+            reset_awg_and_capunits = True,
         ).get_counts(targets=self.classical_registers)
 
     def execute(self, program: str, shots: int = 1024) -> tuple[dict, str]:


### PR DESCRIPTION
Allow the reset of AWG and capacitance units to occur during the execution of a circuit.