### PR TITLE
feat: add noise model support to Qulacs backend (topology-based depolarizing + readout error)

### DIFF
--- a/config/config.yaml.qulacs
+++ b/config/config.yaml.qulacs
@@ -14,6 +14,17 @@ plugin:
   backend:
     module_path: "device_gateway.plugins.qulacs.backend"
     class_name: "QulacsBackend"
+  # Optional noise model for qulacs
+  # noise_model:
+  #   enabled: true
+  #   # If omitted, use topology fidelity:
+  #   # qubits[].fidelity / couplings[].fidelity
+  #   use_topology_fidelity: true
+  #   # Optional fixed values (override topology when set)
+  #   # single_qubit_depolarizing: 0.001
+  #   # two_qubit_depolarizing: 0.01
+  #   # Apply qubits[].meas_error to measured bits
+  #   readout_error: true
 
 # Qubex plugin configuration. Uncomment to use Qubex backend
 # plugin:

--- a/config/example/config.yaml
+++ b/config/example/config.yaml
@@ -14,6 +14,17 @@ plugin:
   backend:
     module_path: "device_gateway.plugins.qulacs.backend"
     class_name: "QulacsBackend"
+  # Optional noise model for qulacs
+  # noise_model:
+  #   enabled: true
+  #   # If omitted, use topology fidelity:
+  #   # qubits[].fidelity / couplings[].fidelity
+  #   use_topology_fidelity: true
+  #   # Optional fixed values (override topology when set)
+  #   # single_qubit_depolarizing: 0.001
+  #   # two_qubit_depolarizing: 0.01
+  #   # Apply qubits[].meas_error to measured bits
+  #   readout_error: true
 
 # Qubex plugin configuration. Uncomment to use Qubex backend
 # plugin:

--- a/src/device_gateway/plugins/qulacs/backend.py
+++ b/src/device_gateway/plugins/qulacs/backend.py
@@ -3,6 +3,7 @@ from collections import Counter
 
 from qiskit.qasm3 import loads
 from qulacs import QuantumCircuit as QulacsQuantumCircuit
+from qulacs import NoiseSimulator
 from qulacs import QuantumState
 
 from device_gateway.core.base_backend import SUCCESS_MESSAGE, BaseBackend
@@ -18,14 +19,117 @@ class QulacsBackend(BaseBackend):
     def _get_circuit(self) -> QulacsCircuit:
         return QulacsCircuit(self)
 
+    def _noise_enabled(self) -> bool:
+        plugin_config = self.config.get("plugin", {})
+        noise_model = plugin_config.get("noise_model", {})
+        return bool(noise_model.get("enabled", False))
+
+    def _noise_model_config(self) -> dict:
+        plugin_config = self.config.get("plugin", {})
+        return plugin_config.get("noise_model", {})
+
+    def _readout_error_enabled(self) -> bool:
+        return bool(self._noise_enabled() and self._noise_model_config().get("readout_error", True))
+
+    def _validate_probability(self, prob: float, name: str) -> float:
+        if not (0.0 <= prob <= 1.0):
+            raise ValueError(f"{name} must be in [0, 1], got {prob}")
+        return prob
+
+    def _build_readout_error_map(self, measure_map: dict[int, int]) -> dict[int, tuple[float, float]]:
+        qubits = self.device_topology.get("qubits", [])
+        qubit_error_map = {
+            qubit.get("id"): qubit.get("meas_error", {}) for qubit in qubits
+        }
+        readout_error_map: dict[int, tuple[float, float]] = {}
+        for clbit_index, qubit_index in measure_map.items():
+            meas_error = qubit_error_map.get(qubit_index, {})
+            p10 = self._validate_probability(
+                float(meas_error.get("prob_meas1_prep0", 0.0)),
+                f"prob_meas1_prep0 for qubit {qubit_index}",
+            )
+            p01 = self._validate_probability(
+                float(meas_error.get("prob_meas0_prep1", 0.0)),
+                f"prob_meas0_prep1 for qubit {qubit_index}",
+            )
+            readout_error_map[clbit_index] = (p10, p01)
+        return readout_error_map
+
+    def _round_distribution(self, dist: dict[int, float], shots: int) -> dict[int, int]:
+        floored = {state: int(value) for state, value in dist.items() if value > 0}
+        remainder = shots - sum(floored.values())
+        if remainder <= 0:
+            return floored
+
+        fractions = sorted(
+            (
+                (state, dist[state] - floored.get(state, 0))
+                for state in dist
+                if dist[state] > 0
+            ),
+            key=lambda item: item[1],
+            reverse=True,
+        )
+        for state, _ in fractions[:remainder]:
+            floored[state] = floored.get(state, 0) + 1
+        return floored
+
+    def _apply_readout_error(
+        self,
+        counts: dict[str, int],
+        measure_map: dict[int, int],
+        bit_count: int,
+    ) -> dict[str, int]:
+        if not self._readout_error_enabled():
+            return counts
+
+        readout_error_map = self._build_readout_error_map(measure_map)
+        if not readout_error_map:
+            return counts
+
+        total_shots = sum(counts.values())
+        dist: dict[int, float] = {int(bitstring, 2): float(count) for bitstring, count in counts.items()}
+
+        for clbit_index in range(bit_count):
+            p10, p01 = readout_error_map.get(clbit_index, (0.0, 0.0))
+            if p10 == 0.0 and p01 == 0.0:
+                continue
+
+            mask = 1 << clbit_index
+            updated_dist: dict[int, float] = {}
+            for state, weight in dist.items():
+                if state & mask:
+                    state_keep = state
+                    state_flip = state & ~mask
+                    updated_dist[state_keep] = updated_dist.get(state_keep, 0.0) + weight * (1.0 - p01)
+                    updated_dist[state_flip] = updated_dist.get(state_flip, 0.0) + weight * p01
+                else:
+                    state_keep = state
+                    state_flip = state | mask
+                    updated_dist[state_keep] = updated_dist.get(state_keep, 0.0) + weight * (1.0 - p10)
+                    updated_dist[state_flip] = updated_dist.get(state_flip, 0.0) + weight * p10
+            dist = updated_dist
+
+        rounded_dist = self._round_distribution(dist, total_shots)
+        remapped_counts = {}
+        for state, count in rounded_dist.items():
+            if count <= 0:
+                continue
+            remapped_counts[format(state, f"0{bit_count}b")] = count
+        return remapped_counts
+
     def _execute(self, circuit: QulacsQuantumCircuit, shots: int = 1024) -> dict:
         """
         Execute the compiled circuit for a specified number of shots.
         The circuit is produced by the Circuit class.
         """
         state = QuantumState(circuit.get_qubit_count())
-        circuit.update_quantum_state(state)
-        result = Counter(state.sampling(shots))
+        if self._noise_enabled():
+            simulator = NoiseSimulator(circuit, state)
+            result = Counter(simulator.execute(shots))
+        else:
+            circuit.update_quantum_state(state)
+            result = Counter(state.sampling(shots))
         counts = {}
         for key, value in result.items():
             counts[format(key, "0" + str(circuit.get_qubit_count()) + "b")] = value
@@ -73,6 +177,8 @@ class QulacsBackend(BaseBackend):
 
         bit_count = len(qc.clbits)
         counts = self._remap_counts(counts, measure_map, bit_count)
+        counts = self._apply_readout_error(counts, measure_map, bit_count)
+        counts = self._remove_zero_values(counts)
         logger.info(f"counts={counts}")
 
         return counts, SUCCESS_MESSAGE

--- a/src/device_gateway/plugins/qulacs/circuit.py
+++ b/src/device_gateway/plugins/qulacs/circuit.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 
 from qiskit import QuantumCircuit as QiskitQuantumCircuit
 from qulacs import QuantumCircuit as QulacsQuantumCircuit
+from qulacs.gate import DepolarizingNoise, TwoQubitDepolarizingNoise
 
 from device_gateway.core.base_circuit import BaseCircuit
 from device_gateway.core.gate_set import SUPPORTED_GATES
@@ -23,6 +24,91 @@ class QulacsCircuit(BaseCircuit):
             backend: Backend to execute the circuit on
         """
         self._backend = backend
+
+    @property
+    def _noise_model_config(self) -> dict:
+        plugin_config = self._backend.config.get("plugin", {})
+        return plugin_config.get("noise_model", {})
+
+    def _noise_enabled(self) -> bool:
+        return bool(self._noise_model_config.get("enabled", False))
+
+    def _use_topology_fidelity(self) -> bool:
+        return bool(self._noise_model_config.get("use_topology_fidelity", True))
+
+    def _validate_probability(self, prob: float, name: str) -> float:
+        if not (0.0 <= prob <= 1.0):
+            raise ValueError(f"{name} must be in [0, 1], got {prob}")
+        return prob
+
+    def _single_qubit_noise_prob(self, target: str) -> float:
+        configured_prob = self._noise_model_config.get("single_qubit_depolarizing")
+        if configured_prob is not None:
+            return self._validate_probability(
+                float(configured_prob), "single_qubit_depolarizing"
+            )
+
+        if not self._use_topology_fidelity():
+            return 0.0
+
+        qubit_id = self._backend.physical_label_to_physical_index[target]
+        for qubit in self._backend.device_topology.get("qubits", []):
+            if qubit.get("id") == qubit_id:
+                fidelity = float(qubit.get("fidelity", 1.0))
+                return self._validate_probability(1.0 - fidelity, "qubit fidelity")
+        return 0.0
+
+    def _two_qubit_noise_prob(self, control: str, target: str) -> float:
+        configured_prob = self._noise_model_config.get("two_qubit_depolarizing")
+        if configured_prob is not None:
+            return self._validate_probability(
+                float(configured_prob), "two_qubit_depolarizing"
+            )
+
+        if not self._use_topology_fidelity():
+            return 0.0
+
+        control_id = self._backend.physical_label_to_physical_index[control]
+        target_id = self._backend.physical_label_to_physical_index[target]
+        couplings = self._backend.device_topology.get("couplings", [])
+        for coupling in couplings:
+            if (
+                coupling.get("control") == control_id
+                and coupling.get("target") == target_id
+            ):
+                fidelity = float(coupling.get("fidelity", 1.0))
+                return self._validate_probability(1.0 - fidelity, "coupling fidelity")
+        return 0.0
+
+    def _add_single_qubit_noise(
+        self, circuit: QulacsQuantumCircuit, target: str
+    ) -> QulacsQuantumCircuit:
+        if not self._noise_enabled():
+            return circuit
+        prob = self._single_qubit_noise_prob(target)
+        if prob <= 0.0:
+            return circuit
+        circuit.add_gate(
+            DepolarizingNoise(self._backend.physical_label_to_physical_index[target], prob)
+        )
+        return circuit
+
+    def _add_two_qubit_noise(
+        self, circuit: QulacsQuantumCircuit, control: str, target: str
+    ) -> QulacsQuantumCircuit:
+        if not self._noise_enabled():
+            return circuit
+        prob = self._two_qubit_noise_prob(control, target)
+        if prob <= 0.0:
+            return circuit
+        circuit.add_gate(
+            TwoQubitDepolarizingNoise(
+                self._backend.physical_label_to_physical_index[control],
+                self._backend.physical_label_to_physical_index[target],
+                prob,
+            )
+        )
+        return circuit
 
     def cx(self, circuit: QulacsQuantumCircuit, control: str, target: str):
         """Apply CX gate."""
@@ -102,17 +188,23 @@ class QulacsCircuit(BaseCircuit):
 
             if name == "x":
                 circuit = self.x(circuit, physical_label)
+                circuit = self._add_single_qubit_noise(circuit, physical_label)
             elif name == "sx":
                 circuit = self.sx(circuit, physical_label)
+                circuit = self._add_single_qubit_noise(circuit, physical_label)
             elif name == "rz":
                 angle = instruction.params[0]
                 circuit = self.rz(circuit, physical_label, angle)
+                circuit = self._add_single_qubit_noise(circuit, physical_label)
             elif name == "cx":
                 physical_target_index = qc.find_bit(instruction.qubits[1]).index
                 physical_target_label = self._backend.physical_label(
                     physical_target_index
                 )
                 circuit = self.cx(circuit, physical_label, physical_target_label)
+                circuit = self._add_two_qubit_noise(
+                    circuit, physical_label, physical_target_label
+                )
             else:
                 pass
 

--- a/tests/device_gateway/plugins/qulacs/test_backend.py
+++ b/tests/device_gateway/plugins/qulacs/test_backend.py
@@ -1,4 +1,5 @@
 import json
+from copy import deepcopy
 
 from device_gateway.plugins.qulacs.backend import QulacsBackend
 
@@ -47,6 +48,151 @@ device_topology = """{
 
 
 class TestQulacsBackend:
+    def test_execute__noise_disabled_is_backward_compatible(self, mocker) -> None:
+        # Arrange
+        mocker.patch(
+            "device_gateway.core.base_backend.BaseBackend.load_device_topology",
+            return_value=json.loads(device_topology),
+        )
+        backend = QulacsBackend({})
+        program = """
+            OPENQASM 3;
+            include "stdgates.inc";
+            bit[1] c;
+            x $0;
+            c[0] = measure $0;
+        """
+
+        # Act
+        counts, message = backend.execute(program, shots=1000)
+
+        # Assert
+        assert isinstance(counts, dict)
+        assert counts == {"1": 1000}
+        assert message == "job is succeeded"
+
+    def test_execute__single_qubit_noise_enabled(self, mocker) -> None:
+        # Arrange
+        mocker.patch(
+            "device_gateway.core.base_backend.BaseBackend.load_device_topology",
+            return_value=json.loads(device_topology),
+        )
+        config = {
+            "plugin": {
+                "name": "qulacs",
+                "noise_model": {
+                    "enabled": True,
+                    "single_qubit_depolarizing": 1.0,
+                    "two_qubit_depolarizing": 0.0,
+                },
+            }
+        }
+        backend = QulacsBackend(config)
+        program = """
+            OPENQASM 3;
+            include "stdgates.inc";
+            bit[1] c;
+            x $0;
+            c[0] = measure $0;
+        """
+
+        # Act
+        counts, message = backend.execute(program, shots=2000)
+
+        # Assert
+        assert isinstance(counts, dict)
+        assert "0" in counts
+        assert "1" in counts
+        assert message == "job is succeeded"
+
+    def test_execute__single_qubit_noise_from_topology_fidelity(self, mocker) -> None:
+        # Arrange
+        topology = deepcopy(json.loads(device_topology))
+        for qubit in topology["qubits"]:
+            qubit["fidelity"] = 1.0
+            qubit["meas_error"] = {
+                "prob_meas1_prep0": 0.0,
+                "prob_meas0_prep1": 0.0,
+            }
+        topology["qubits"][0]["fidelity"] = 0.0
+
+        mocker.patch(
+            "device_gateway.core.base_backend.BaseBackend.load_device_topology",
+            return_value=topology,
+        )
+        config = {
+            "plugin": {
+                "name": "qulacs",
+                "noise_model": {
+                    "enabled": True,
+                    "use_topology_fidelity": True,
+                    "readout_error": False,
+                },
+            }
+        }
+        backend = QulacsBackend(config)
+        program = """
+            OPENQASM 3;
+            include "stdgates.inc";
+            bit[1] c;
+            x $0;
+            c[0] = measure $0;
+        """
+
+        # Act
+        counts, message = backend.execute(program, shots=2000)
+
+        # Assert
+        assert isinstance(counts, dict)
+        assert "0" in counts
+        assert "1" in counts
+        assert message == "job is succeeded"
+
+    def test_execute__readout_error_from_topology(self, mocker) -> None:
+        # Arrange
+        topology = deepcopy(json.loads(device_topology))
+        for qubit in topology["qubits"]:
+            qubit["fidelity"] = 1.0
+            qubit["meas_error"] = {
+                "prob_meas1_prep0": 0.0,
+                "prob_meas0_prep1": 0.0,
+            }
+        topology["qubits"][0]["meas_error"] = {
+            "prob_meas1_prep0": 1.0,
+            "prob_meas0_prep1": 0.0,
+        }
+
+        mocker.patch(
+            "device_gateway.core.base_backend.BaseBackend.load_device_topology",
+            return_value=topology,
+        )
+        config = {
+            "plugin": {
+                "name": "qulacs",
+                "noise_model": {
+                    "enabled": True,
+                    "single_qubit_depolarizing": 0.0,
+                    "two_qubit_depolarizing": 0.0,
+                    "readout_error": True,
+                },
+            }
+        }
+        backend = QulacsBackend(config)
+        program = """
+            OPENQASM 3;
+            include "stdgates.inc";
+            bit[1] c;
+            c[0] = measure $0;
+        """
+
+        # Act
+        counts, message = backend.execute(program, shots=1000)
+
+        # Assert
+        assert isinstance(counts, dict)
+        assert counts == {"1": 1000}
+        assert message == "job is succeeded"
+
     def test_execute(self, mocker) -> None:
         # Arrange
         mocker.patch(


### PR DESCRIPTION
## Summary
This PR introduces noise model support for the Qulacs backend.

Previously, the backend ran in ideal simulation mode only.
With this change, users can enable noise simulation and optionally derive noise parameters from `device_topology`.

## What changed

### 1. Qulacs backend execution mode
- Added noise mode switch in `QulacsBackend`.
- When `plugin.noise_model.enabled=true`, execution uses `NoiseSimulator`.
- When disabled, behavior remains unchanged (`QuantumState` path).

### 2. Gate noise support in Qulacs circuit
- Added depolarizing noise injection after supported gates in `QulacsCircuit`.
- Supports:
  - single-qubit depolarizing noise
  - two-qubit depolarizing noise
- Noise probability source:
  - config override (`single_qubit_depolarizing`, `two_qubit_depolarizing`) if set
  - otherwise topology-derived (`p = 1 - fidelity`) when `use_topology_fidelity=true`

### 3. Readout error handling
- Added readout error application based on topology `meas_error` values:
  - `prob_meas1_prep0`
  - `prob_meas0_prep1`
- Applied as post-processing on measurement counts when `readout_error=true`.
- Includes probability range validation (`[0, 1]`).

### 4. Config examples updated
- Updated:
  - `config/config.yaml.qulacs`
  - `config/example/config.yaml`
- Added `plugin.noise_model` example keys and comments.

### 5. Tests added
- Extended `tests/device_gateway/plugins/qulacs/test_backend.py` with:
  - backward compatibility when noise is disabled
  - fixed-probability single-qubit noise behavior
  - topology-fidelity-based noise behavior
  - topology-based readout error behavior

## Config (new)
Under `plugin.noise_model`:
- `enabled`
- `use_topology_fidelity`
- `single_qubit_depolarizing` (optional)
- `two_qubit_depolarizing` (optional)
- `readout_error`

## Validation
- `uv run ruff check src/device_gateway/plugins/qulacs/backend.py src/device_gateway/plugins/qulacs/circuit.py tests/device_gateway/plugins/qulacs/test_backend.py`
- `uv run pytest tests/device_gateway/plugins/qulacs/test_backend.py -q`

## Notes / Limitations
- 2Q topology lookup currently matches coupling direction as-is (`control -> target`).
- Readout error is implemented as counts post-processing (not native gate insertion).