### PR TITLE
feat(security): add job integrity attestation module

### DIFF
--- a/src/device_gateway/security/attestation.py
+++ b/src/device_gateway/security/attestation.py
@@ -1,0 +1,54 @@
+import hashlib
+import json
+import time
+import uuid
+
+
+def hash_program(program: str) -> str:
+    """Return SHA-256 hex digest of an OpenQASM 3 program string."""
+    return hashlib.sha256(program.encode("utf-8")).hexdigest()
+
+
+def hash_counts(counts: dict[str, int]) -> str:
+    """Return SHA-256 hex digest of canonical JSON representation of counts."""
+    canonical = json.dumps(counts, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def hash_device_info(device_id: str, calibrated_at: str) -> str:
+    """Return SHA-256 hex digest of device_id concatenated with calibrated_at."""
+    payload = device_id + calibrated_at
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def create_job_attestation(
+    job_id: str,
+    program: str,
+    counts: dict[str, int],
+    device_id: str,
+    calibrated_at: str = "",
+) -> dict:
+    """Create an integrity attestation record for a completed job.
+
+    Returns a dict containing hashes, timestamp, and a unique attestation id.
+    """
+    return {
+        "job_id": job_id,
+        "program_hash": hash_program(program),
+        "counts_hash": hash_counts(counts),
+        "device_info_hash": hash_device_info(device_id, calibrated_at),
+        "timestamp": time.time(),
+        "attestation_id": str(uuid.uuid4()),
+    }
+
+
+def verify_attestation(
+    attestation: dict,
+    program: str,
+    counts: dict[str, int],
+) -> bool:
+    """Verify that program and counts match the hashes stored in an attestation."""
+    return (
+        attestation.get("program_hash") == hash_program(program)
+        and attestation.get("counts_hash") == hash_counts(counts)
+    )

--- a/src/device_gateway/service.py
+++ b/src/device_gateway/service.py
@@ -16,6 +16,7 @@ from device_gateway.core.plugin_manager import (
     BackendPluginManager,
 )
 from device_gateway.gen.qpu.v1 import qpu_pb2, qpu_pb2_grpc
+from device_gateway.security.attestation import create_job_attestation
 
 logger = logging.getLogger("device_gateway")
 
@@ -126,6 +127,10 @@ class ServerImpl(qpu_pb2_grpc.QpuServiceServicer):
 
             logger.info(f"program={request.program}, shots={request.shots}")
             counts, message = self.backend.execute(request.program, shots=request.shots)
+            attestation = create_job_attestation(
+                job_id, request.program, counts, self.backend.device_info.get("device_id", "unknown")
+            )
+            logger.info(f"job_attestation={attestation}")
             result = qpu_pb2.Result(counts=counts, message=message)  # type: ignore[attr-defined]
             response = qpu_pb2.CallJobResponse(  # type: ignore[attr-defined]
                 status=qpu_pb2.JobStatus.JOB_STATUS_SUCCESS,  # type: ignore[attr-defined]

--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -1,0 +1,67 @@
+import hashlib
+import json
+
+from device_gateway.security.attestation import (
+    create_job_attestation,
+    hash_counts,
+    hash_device_info,
+    hash_program,
+    verify_attestation,
+)
+
+SAMPLE_PROGRAM = 'OPENQASM 3.0;\nqubit[2] q;\nh q[0];\ncx q[0], q[1];\nbit[2] c;\nc = measure q;'
+SAMPLE_COUNTS = {"00": 500, "11": 500}
+
+
+def test_hash_program_known_output():
+    expected = hashlib.sha256(SAMPLE_PROGRAM.encode("utf-8")).hexdigest()
+    assert hash_program(SAMPLE_PROGRAM) == expected
+
+
+def test_hash_program_deterministic():
+    assert hash_program(SAMPLE_PROGRAM) == hash_program(SAMPLE_PROGRAM)
+
+
+def test_hash_counts_known_output():
+    canonical = json.dumps(SAMPLE_COUNTS, sort_keys=True, separators=(",", ":"))
+    expected = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    assert hash_counts(SAMPLE_COUNTS) == expected
+
+
+def test_hash_counts_order_independent():
+    counts_a = {"00": 500, "11": 500}
+    counts_b = {"11": 500, "00": 500}
+    assert hash_counts(counts_a) == hash_counts(counts_b)
+
+
+def test_hash_device_info_known_output():
+    device_id = "device-1"
+    calibrated_at = "2025-01-01T00:00:00Z"
+    payload = device_id + calibrated_at
+    expected = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    assert hash_device_info(device_id, calibrated_at) == expected
+
+
+def test_create_job_attestation_fields():
+    att = create_job_attestation("job-1", SAMPLE_PROGRAM, SAMPLE_COUNTS, "dev-1")
+    assert att["job_id"] == "job-1"
+    assert att["program_hash"] == hash_program(SAMPLE_PROGRAM)
+    assert att["counts_hash"] == hash_counts(SAMPLE_COUNTS)
+    assert "timestamp" in att
+    assert "attestation_id" in att
+
+
+def test_verify_attestation_roundtrip():
+    att = create_job_attestation("job-2", SAMPLE_PROGRAM, SAMPLE_COUNTS, "dev-1")
+    assert verify_attestation(att, SAMPLE_PROGRAM, SAMPLE_COUNTS) is True
+
+
+def test_verify_attestation_tampered_counts():
+    att = create_job_attestation("job-3", SAMPLE_PROGRAM, SAMPLE_COUNTS, "dev-1")
+    tampered = {"00": 999, "11": 1}
+    assert verify_attestation(att, SAMPLE_PROGRAM, tampered) is False
+
+
+def test_verify_attestation_tampered_program():
+    att = create_job_attestation("job-4", SAMPLE_PROGRAM, SAMPLE_COUNTS, "dev-1")
+    assert verify_attestation(att, "OPENQASM 3.0; // tampered", SAMPLE_COUNTS) is False


### PR DESCRIPTION
# 📃 Ticket

Closes #78

## ✍ Description

The current `CallJob` implementation has no cryptographic integrity 
verification between job submission and result return. This adds a 
lightweight attestation module using Python stdlib only (zero new 
dependencies).

## 📸 Test Result

9 passed in 0.21s
test_hash_program_known_output PASSED
test_hash_program_deterministic PASSED
test_hash_counts_known_output PASSED
test_hash_counts_order_independent PASSED
test_hash_device_info_known_output PASSED
test_create_job_attestation_fields PASSED
test_verify_attestation_roundtrip PASSED
test_verify_attestation_tampered_counts PASSED
test_verify_attestation_tampered_program PASSED

## 🔗 
None


