### PR TITLE
feat: derive device_id and max_qubits from topology when omitted in config

### DIFF
--- a/config/config.yaml.qubex
+++ b/config/config.yaml.qubex
@@ -3,9 +3,9 @@ proto:
   address: "[::]:51021"
 
 device_info:
-  device_id: "anemone"
+  # device_id: "anemone"
   provider_id: "qiqb"
-  max_qubits: 7
+  # max_qubits: 16
   max_shots: 10000
 
 # Plugin configuration

--- a/config/config.yaml.qulacs
+++ b/config/config.yaml.qulacs
@@ -3,9 +3,9 @@ proto:
   address: "[::]:51021"
 
 device_info:
-  device_id: "anemone"
-  provider_id: "qiqb"
-  max_qubits: 7
+  # device_id: "qulacs"
+  provider_id: "oqtopus"
+  # max_qubits: 16
   max_shots: 10000
 
 # Plugin configuration

--- a/config/example/config.yaml
+++ b/config/example/config.yaml
@@ -3,9 +3,9 @@ proto:
   address: "[::]:51021"
 
 device_info:
-  device_id: "qulacs"
+  # device_id: "qulacs"
   provider_id: "oqtopus"
-  max_qubits: 3
+  # max_qubits: 16
   max_shots: 10000
 
 # Plugin configuration

--- a/config/example/device_topology_sim.json
+++ b/config/example/device_topology_sim.json
@@ -1,6 +1,6 @@
 {
   "name": "qulacs",
-  "device_id": "qiqb",
+  "device_id": "qulacs",
   "qubits": [
     {
       "id": 0,

--- a/src/device_gateway/core/base_backend.py
+++ b/src/device_gateway/core/base_backend.py
@@ -84,7 +84,7 @@ class BaseBackend(metaclass=ABCMeta):
         Returns the device topology, e.g., {"qubits": [{"id": 0, "physical_id": 5}], "couplings": [{"control": 0, "target": 1}]}
         """
         return self.load_device_topology()
-    
+
     @property
     def physical_ids(self) -> list:
         """
@@ -102,13 +102,24 @@ class BaseBackend(metaclass=ABCMeta):
     @property
     def device_info(self) -> dict:
         """
-        Returns the device information, e.g., {"device_id": "QPU1", "device_type": "QPU"}
+        Returns the device information, e.g., {"device_id": "QPU1", "type": "QPU"}
         """
-        if self.is_simulator():
-            self.config["device_info"]["type"] = "simulator"
-        else:
-            self.config["device_info"]["type"] = "QPU"
-        return self.config["device_info"]
+        info = dict(self.config["device_info"])
+        info["type"] = "simulator" if self.is_simulator() else "QPU"
+
+        # Load topology once when either field needs a fallback value
+        if info.get("device_id") is None or info.get("max_qubits") is None:
+            topology = self.load_device_topology()
+            if info.get("device_id") is None:
+                if "device_id" not in topology:
+                    raise ValueError("device_id is not set in config and not found in topology")
+                info["device_id"] = topology["device_id"]
+            if info.get("max_qubits") is None:
+                if "qubits" not in topology:
+                    raise ValueError("max_qubits is not set in config and qubits not found in topology")
+                info["max_qubits"] = len(topology["qubits"])
+
+        return info
 
     @property
     def physical_map(self):

--- a/tests/device_gateway/core/test_base_backend.py
+++ b/tests/device_gateway/core/test_base_backend.py
@@ -1,0 +1,94 @@
+import pytest
+
+from device_gateway.plugins.qulacs.backend import QulacsBackend
+
+
+def make_config(device_id="from_config", max_qubits=7):
+    return {
+        "device_info": {
+            "device_id": device_id,
+            "max_qubits": max_qubits,
+            "provider_id": "oqtopus",
+            "max_shots": 1000,
+        },
+        "plugin": {"name": "qulacs"},
+    }
+
+
+def make_topology(device_id="from_topology", num_qubits=4):
+    return {
+        "device_id": device_id,
+        "qubits": [{"id": i, "physical_id": i} for i in range(num_qubits)],
+    }
+
+
+class TestDeviceInfo:
+    def test_uses_config_values_when_set(self, mocker):
+        mocker.patch(
+            "device_gateway.core.base_backend.BaseBackend.load_device_topology",
+            return_value=make_topology(device_id="topology_id", num_qubits=4),
+        )
+        backend = QulacsBackend(make_config(device_id="config_id", max_qubits=7))
+
+        info = backend.device_info
+
+        assert info["device_id"] == "config_id"
+        assert info["max_qubits"] == 7
+
+    def test_uses_topology_device_id_when_config_device_id_is_none(self, mocker):
+        mocker.patch(
+            "device_gateway.core.base_backend.BaseBackend.load_device_topology",
+            return_value=make_topology(device_id="topology_id"),
+        )
+        backend = QulacsBackend(make_config(device_id=None))
+
+        info = backend.device_info
+
+        assert info["device_id"] == "topology_id"
+
+    def test_uses_topology_qubits_count_when_config_max_qubits_is_none(self, mocker):
+        mocker.patch(
+            "device_gateway.core.base_backend.BaseBackend.load_device_topology",
+            return_value=make_topology(num_qubits=5),
+        )
+        backend = QulacsBackend(make_config(max_qubits=None))
+
+        info = backend.device_info
+
+        assert info["max_qubits"] == 5
+
+    def test_raises_error_when_device_id_missing_from_both_config_and_topology(self, mocker):
+        topology = make_topology()
+        del topology["device_id"]
+        mocker.patch(
+            "device_gateway.core.base_backend.BaseBackend.load_device_topology",
+            return_value=topology,
+        )
+        backend = QulacsBackend(make_config(device_id=None))
+
+        with pytest.raises(ValueError, match="device_id"):
+            backend.device_info
+
+    def test_raises_error_when_max_qubits_missing_from_both_config_and_topology(self, mocker):
+        topology = make_topology()
+        del topology["qubits"]
+        mocker.patch(
+            "device_gateway.core.base_backend.BaseBackend.load_device_topology",
+            return_value=topology,
+        )
+        backend = QulacsBackend(make_config(max_qubits=None))
+
+        with pytest.raises(ValueError, match="max_qubits"):
+            backend.device_info
+
+    def test_does_not_mutate_config(self, mocker):
+        mocker.patch(
+            "device_gateway.core.base_backend.BaseBackend.load_device_topology",
+            return_value=make_topology(device_id="topology_id", num_qubits=5),
+        )
+        backend = QulacsBackend(make_config(device_id=None, max_qubits=None))
+
+        backend.device_info
+
+        assert backend.config["device_info"]["device_id"] is None
+        assert backend.config["device_info"]["max_qubits"] is None


### PR DESCRIPTION
This pull request improves how device information is handled and validated in the backend, especially when configuration values are missing. It introduces logic to fall back to topology data when certain fields are not set in the config, and adds comprehensive tests to ensure correct behavior and error handling. Additionally, several config files are updated to reflect the new approach of making `device_id` and `max_qubits` optional.

**Device info fallback logic and validation:**

* Updated the `device_info` property in `BaseBackend` to fall back to topology data for `device_id` and `max_qubits` if they are not set in the config, and to raise clear errors if these fields are missing from both sources. Also ensures the config dictionary is not mutated during this process.

**Testing improvements:**

* Added a new test suite (`tests/device_gateway/core/test_base_backend.py`) that verifies the fallback behavior, error handling, and immutability of the config for the `device_info` property.

**Configuration file updates:**

* Updated `config/config.yaml.qubex`, `config/config.yaml.qulacs`, and `config/example/config.yaml` to comment out `device_id` and `max_qubits`, reflecting that these fields are now optional and can be loaded from topology if not set. [[1]](diffhunk://#diff-5684f9f882ba4700a44a1f07beee352153ff112caf2486d6245e0405130bf1d1L6-R8) [[2]](diffhunk://#diff-406447b9a34dfe1fe37f7f9a293fb60314aa3970d30cfa65f8073cca560cf346L6-R8)
* Fixed the `device_id` in `config/example/device_topology_sim.json` to match the expected value for the `qulacs` device.