### PR TITLE
fix: update test_service.py to match current ServerImpl implementation

### DIFF
--- a/tests/device_gateway/test_service.py
+++ b/tests/device_gateway/test_service.py
@@ -2,10 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from device_gateway.core.plugin_manager import (
-    BackendPluginManager,
-    CircuitPluginManager,
-)
+from device_gateway.core.plugin_manager import BackendPluginManager
 from device_gateway.service import ServerImpl
 
 
@@ -16,58 +13,34 @@ def mock_backend_manager():
 
 
 @pytest.fixture
-def mock_circuit_manager():
-    manager = MagicMock(spec=CircuitPluginManager)
-    return manager
-
-
-@pytest.fixture
 def config():
     return {"backend": "qulacs"}
 
 
-def test_server_init_with_default_managers(config):
+@pytest.fixture
+def server(mocker, config):
+    def _fake_initialize(self, config):
+        self.backend_name = "qulacs"
+        self.backend = MagicMock()
+
+    mocker.patch.object(ServerImpl, "_initialize_backend", _fake_initialize)
+    return ServerImpl(config)
+
+
+def test_server_init_with_default_managers(server):
     """Test server initialization with default managers."""
-    server = ServerImpl(config)
     assert isinstance(server._backend_manager, BackendPluginManager)
-    assert isinstance(server._circuit_manager, CircuitPluginManager)
 
 
-def test_server_init_with_custom_managers(
-    config, mock_backend_manager, mock_circuit_manager
-):
-    """Test server initialization with custom managers."""
-    server = ServerImpl(
-        config,
-        backend_manager=mock_backend_manager,
-        circuit_manager=mock_circuit_manager,
-    )
-    assert server._backend_manager == mock_backend_manager
-    assert server._circuit_manager == mock_circuit_manager
-
-
-def test_load_plugin_with_unsupported_backend(
-    config, mock_backend_manager, mock_circuit_manager
-):
+def test_load_plugin_with_unsupported_backend(server):
     """Test loading unsupported backend plugin."""
-    server = ServerImpl(
-        config,
-        backend_manager=mock_backend_manager,
-        circuit_manager=mock_circuit_manager,
-    )
     with pytest.raises(ImportError):
-        server._load_plugin("unsupported_backend")
+        server._load_plugin({"name": "unsupported_backend"})
 
 
-def test_load_plugin_with_import_error(
-    config, mock_backend_manager, mock_circuit_manager
-):
+def test_load_plugin_with_import_error(server, mock_backend_manager):
     """Test handling of import error during plugin loading."""
+    server._backend_manager = mock_backend_manager
     mock_backend_manager.load_backend.side_effect = ImportError("Test error")
-    server = ServerImpl(
-        config,
-        backend_manager=mock_backend_manager,
-        circuit_manager=mock_circuit_manager,
-    )
     with pytest.raises(ImportError):
-        server._load_plugin("qulacs")
+        server._load_plugin({"name": "qulacs"})


### PR DESCRIPTION
This pull request refactors the `test_service.py` tests to simplify the setup and remove unused code. The main changes include removing the `CircuitPluginManager` dependency from the tests, updating test fixtures for a more streamlined server initialization, and cleaning up redundant or unnecessary test cases.

**Test simplification and cleanup:**

* Removed all references to `CircuitPluginManager` and related test fixtures, focusing tests solely on `BackendPluginManager` and the server's backend functionality. [[1]](diffhunk://#diff-f32dc4bc76bba16407f9bace965216c1b982e0eb7d596e31a70a1a104f85c971L5-R5) [[2]](diffhunk://#diff-f32dc4bc76bba16407f9bace965216c1b982e0eb7d596e31a70a1a104f85c971L19-R46)
* Refactored the `server` fixture to mock backend initialization, reducing duplication and making tests more isolated.
* Updated tests to use the new `server` fixture and simplified plugin loading tests by passing plugin info as a dictionary instead of a string.
* Removed redundant tests for custom manager initialization, since the focus is now on default backend manager behavior.