### PR TITLE
Add generic Qiskit adapter plugin

### DIFF
--- a/config/config.yaml.qiskit-qm
+++ b/config/config.yaml.qiskit-qm
@@ -1,0 +1,34 @@
+proto:
+  max_workers: 2
+  address: "[::]:51021"
+
+device_info:
+  provider_id: "oqtopus"
+  max_shots: 10000
+
+plugin:
+  name: "qiskit_adapter"
+  backend:
+    module_path: "device_gateway.plugins.qiskit_adapter.backend"
+    class_name: "QiskitAdapterBackend"
+  qiskit_adapter:
+    provider:
+      class: "qiskit_qm_provider.QMProvider"
+      kwargs:
+        state_folder_path: "/path/to/quam/state"
+        # quam_cls:
+        #   class_ref: "my_lab.quam.MyQuam"
+    backend:
+      method: "get_backend"
+      kwargs:
+        simulate: true
+        # backend_cls:
+        #   class_ref: "qiskit_qm_provider.FluxTunableTransmonBackend"
+    transpile_options:
+      optimization_level: 1
+    run_options:
+      memory: false
+    validate: false
+
+device_status_path: config/device_status
+device_topology_json_path: config/device_topology.json

--- a/config/config.yaml.qiskit-qubex
+++ b/config/config.yaml.qiskit-qubex
@@ -1,0 +1,39 @@
+proto:
+  max_workers: 2
+  address: "[::]:51021"
+
+device_info:
+  provider_id: "oqtopus"
+  max_shots: 10000
+
+plugin:
+  name: "qiskit_adapter"
+  backend:
+    module_path: "device_gateway.plugins.qiskit_adapter.backend"
+    class_name: "QiskitAdapterBackend"
+  qiskit_adapter:
+    provider:
+      class: "qiskit_qubex_provider.QubexProvider"
+      factory: "from_experiment_config"
+      kwargs:
+        name: "qubex"
+        device_topology: "config/device_topology.json"
+        connect_devices: true
+        native: false
+        # system_id: "64Q-HF-Q1"
+        # chip_id: "64Q"
+        # config_dir: "/app/qubex-config/64Q/config"
+        # params_dir: "/app/qubex-config/64Q/params"
+    backend:
+      method: "get_backend"
+      kwargs: {}
+    transpile_options:
+      scheduling_method: "alap"
+      optimization_level: 1
+    run_options:
+      memory: false
+      plot: false
+    validate: true
+
+device_status_path: config/device_status
+device_topology_json_path: config/device_topology.json

--- a/src/device_gateway/core/object_loader.py
+++ b/src/device_gateway/core/object_loader.py
@@ -1,0 +1,64 @@
+"""Helpers for loading configured Python objects."""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+def load_object(spec: Mapping[str, Any]) -> Any:
+    """Load an object from a config mapping.
+
+    Supported forms:
+      - ``class: "pkg.module.Class"`` with optional ``kwargs``.
+      - ``module_path`` + ``class_name`` with optional ``kwargs``.
+      - either class form plus ``factory`` to call a classmethod.
+      - ``module_path`` + ``factory`` to call a module-level factory.
+    """
+    kwargs = resolve_references(dict(spec.get("kwargs", {})))
+    class_ref = spec.get("class")
+    module_path = spec.get("module_path")
+    class_name = spec.get("class_name")
+    factory_name = spec.get("factory")
+
+    if class_ref:
+        target = import_ref(str(class_ref))
+        if factory_name:
+            return getattr(target, str(factory_name))(**kwargs)
+        return target(**kwargs)
+
+    if not module_path:
+        raise ValueError("Object spec requires class or module_path.")
+
+    module = importlib.import_module(str(module_path))
+    if class_name:
+        target = getattr(module, str(class_name))
+        if factory_name:
+            return getattr(target, str(factory_name))(**kwargs)
+        return target(**kwargs)
+
+    if factory_name:
+        return getattr(module, str(factory_name))(**kwargs)
+
+    raise ValueError("Object spec requires class_name or factory when using module_path.")
+
+
+def import_ref(ref: str) -> Any:
+    """Import ``module.attr`` and return the referenced object."""
+    module_name, _, attr_name = ref.rpartition(".")
+    if not module_name or not attr_name:
+        raise ValueError(f"Invalid import reference: {ref!r}")
+    module = importlib.import_module(module_name)
+    return getattr(module, attr_name)
+
+
+def resolve_references(value: Any) -> Any:
+    """Resolve nested ``class_ref`` mappings inside config values."""
+    if isinstance(value, Mapping):
+        if set(value) == {"class_ref"}:
+            return import_ref(str(value["class_ref"]))
+        return {key: resolve_references(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [resolve_references(item) for item in value]
+    return value

--- a/src/device_gateway/core/plugin_manager.py
+++ b/src/device_gateway/core/plugin_manager.py
@@ -8,7 +8,7 @@ from device_gateway.core.base_backend import BaseBackend
 
 logger = logging.getLogger("device_gateway")
 
-SUPPORTED_BACKENDS = ("qulacs", "qubex")  # Tuple of supported backend names
+SUPPORTED_BACKENDS = ("qulacs", "qubex", "qiskit_adapter")  # Built-in backend names
 
 
 class BackendPluginManager:
@@ -71,7 +71,13 @@ class BackendPluginManager:
             name = plugin_config.get("name", "qulacs")
             backend_settings = plugin_config.get("backend", {})
             default_module_path = f"device_gateway.plugins.{name}.backend"
-            default_class_name = f"{name.capitalize()}Backend"
+            default_class_names = {
+                "qiskit_adapter": "QiskitAdapterBackend",
+            }
+            default_class_name = default_class_names.get(
+                name,
+                f"{name.capitalize()}Backend",
+            )
 
             module_path = backend_settings.get("module_path", default_module_path)
             class_name = backend_settings.get("class_name", default_class_name)

--- a/src/device_gateway/plugins/qiskit_adapter/__init__.py
+++ b/src/device_gateway/plugins/qiskit_adapter/__init__.py
@@ -1,0 +1,1 @@
+"""Generic Qiskit adapter plugin."""

--- a/src/device_gateway/plugins/qiskit_adapter/backend.py
+++ b/src/device_gateway/plugins/qiskit_adapter/backend.py
@@ -1,0 +1,128 @@
+"""Generic Qiskit backend adapter for Device Gateway.
+
+This plugin lets Device Gateway host a Qiskit backend or a provider that
+returns one. Device Gateway keeps the OQTOPUS service boundary while the loaded
+Qiskit backend owns transpilation targets, validation, execution, and result
+conversion.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from qiskit import transpile
+from qiskit.qasm3 import loads
+
+from device_gateway.core.base_backend import SUCCESS_MESSAGE, BaseBackend
+from device_gateway.core.object_loader import load_object, resolve_references
+
+logger = logging.getLogger("device_gateway")
+
+
+class QiskitAdapterBackend(BaseBackend):
+    """Device Gateway backend that delegates execution to a Qiskit backend."""
+
+    def __init__(self, config: dict):
+        super().__init__(config)
+        plugin_config = config.get("plugin", {})
+        self._qiskit_config = plugin_config.get(
+            "qiskit_adapter",
+            plugin_config.get("qiskit", {}),
+        )
+        self._backend = self._load_backend()
+
+    def _get_circuit(self) -> Any:
+        """Return the delegated Qiskit backend for compatibility hooks."""
+        return self._backend
+
+    def _execute(self, circuit: Any, shots: int = 1024) -> dict[str, int]:
+        """Execute a Qiskit circuit on the delegated backend."""
+        run_options = resolve_references(
+            dict(self._qiskit_config.get("run_options", {}))
+        )
+        run_options["shots"] = shots
+        job = self._backend.run(circuit, **run_options)
+        result = job.result()
+        counts = result.get_counts()
+        if isinstance(counts, list):
+            if len(counts) != 1:
+                raise ValueError(
+                    "Device Gateway CallJob expects one result count mapping, "
+                    f"but Qiskit returned {len(counts)} mappings."
+                )
+            counts = counts[0]
+        bit_count = max(
+            getattr(circuit, "num_clbits", 0),
+            getattr(circuit, "num_qubits", 0),
+            1,
+        )
+        return {
+            _format_count_key(str(key), bit_count): int(value)
+            for key, value in counts.items()
+        }
+
+    def execute(self, program: str, shots: int = 1024) -> tuple[dict[str, int], str]:
+        """Parse OpenQASM 3 and execute it through the configured Qiskit backend."""
+        circuit = loads(program)
+        compiled = self._transpile(circuit)
+        self._validate(compiled)
+        counts = self._execute(compiled, shots=shots)
+        counts = self._remove_zero_values(counts)
+        logger.info("counts=%s", counts)
+        return counts, SUCCESS_MESSAGE
+
+    def _transpile(self, circuit: Any) -> Any:
+        transpile_options = self._qiskit_config.get("transpile_options")
+        if transpile_options is False:
+            return circuit
+        options = resolve_references(dict(transpile_options or {}))
+        return transpile(circuit, self._backend, **options)
+
+    def _validate(self, circuit: Any) -> None:
+        if not self._qiskit_config.get("validate", True):
+            return
+        validate = getattr(self._backend, "validate", None)
+        if callable(validate):
+            validate(circuit)
+
+    def _load_backend(self) -> Any:
+        backend_spec = self._qiskit_config.get("backend")
+        provider_spec = self._qiskit_config.get("provider")
+        if provider_spec:
+            provider = load_object(provider_spec)
+            backend = self._backend_from_provider(provider, backend_spec)
+        elif backend_spec:
+            backend = load_object(backend_spec)
+        else:
+            raise ValueError(
+                "Qiskit adapter requires plugin.qiskit_adapter.backend or "
+                "plugin.qiskit_adapter.provider configuration."
+            )
+        if not hasattr(backend, "run"):
+            raise TypeError("Configured Qiskit backend must provide run(...).")
+        return backend
+
+    def _backend_from_provider(self, provider: Any, backend_spec: Any) -> Any:
+        if backend_spec is None:
+            method_name = "get_backend"
+            kwargs = {}
+        else:
+            method_name = str(backend_spec.get("method", "get_backend"))
+            kwargs = dict(backend_spec.get("kwargs", {}))
+        backend_filters = dict(self._qiskit_config.get("backend_filters", {}))
+        backend_name = self._qiskit_config.get("backend_name")
+        if backend_name is not None:
+            backend_filters.setdefault("name", backend_name)
+        kwargs = resolve_references({**backend_filters, **kwargs})
+        return getattr(provider, method_name)(**kwargs)
+
+
+QiskitBackend = QiskitAdapterBackend
+
+
+def _format_count_key(key: str, bit_count: int) -> str:
+    """Return Device Gateway count keys as zero-padded bit strings."""
+    if key.startswith("0x"):
+        return format(int(key, 16), f"0{bit_count}b")
+    return key.replace(" ", "")

--- a/src/device_gateway/service.py
+++ b/src/device_gateway/service.py
@@ -57,7 +57,8 @@ class ServerImpl(qpu_pb2_grpc.QpuServiceServicer):
             ImportError: If the specified plugin is not supported.
         """
         name = plugin_config.get("name")
-        if name not in SUPPORTED_BACKENDS:
+        has_explicit_backend = bool(plugin_config.get("backend", {}).get("module_path"))
+        if name not in SUPPORTED_BACKENDS and not has_explicit_backend:
             logger.error(ERROR_UNSUPPORTED_BACKEND.format(plugin_config))
             raise ImportError(ERROR_UNSUPPORTED_BACKEND.format(plugin_config))
 

--- a/tests/device_gateway/plugins/qiskit_adapter/__init__.py
+++ b/tests/device_gateway/plugins/qiskit_adapter/__init__.py
@@ -1,0 +1,1 @@
+"""Qiskit adapter plugin tests."""

--- a/tests/device_gateway/plugins/qiskit_adapter/test_backend.py
+++ b/tests/device_gateway/plugins/qiskit_adapter/test_backend.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from qiskit import QuantumCircuit
+
+from device_gateway.plugins.qiskit_adapter.backend import (
+    QiskitAdapterBackend,
+    _format_count_key,
+)
+
+
+class FakeResult:
+    def get_counts(self):
+        return {"00": 4, "11": 6, "01": 0}
+
+
+class FakeJob:
+    def result(self):
+        return FakeResult()
+
+
+class FakeBackend:
+    def __init__(self):
+        self.run = MagicMock(return_value=FakeJob())
+        self.validate = MagicMock()
+
+
+class FakeBackendClass:
+    pass
+
+
+class FakeProvider:
+    last_kwargs = None
+
+    def __init__(self):
+        self.backend = FakeBackend()
+
+    def get_backend(self, **kwargs):
+        type(self).last_kwargs = kwargs
+        self.kwargs = kwargs
+        return self.backend
+
+
+def make_config():
+    return {
+        "device_info": {"provider_id": "oqtopus", "max_shots": 1000},
+        "plugin": {
+            "name": "qiskit_adapter",
+            "qiskit_adapter": {
+                "provider": {
+                    "class": f"{__name__}.FakeProvider",
+                },
+                "backend": {
+                    "method": "get_backend",
+                    "kwargs": {
+                        "backend_cls": {"class_ref": f"{__name__}.FakeBackendClass"}
+                    },
+                },
+                "transpile_options": False,
+                "run_options": {"memory": False},
+            },
+        },
+    }
+
+
+def test_qiskit_backend_executes_program_through_configured_provider():
+    backend = QiskitAdapterBackend(make_config())
+    program = """
+OPENQASM 3;
+include "stdgates.inc";
+qubit[2] q;
+bit[2] c;
+h q[0];
+cx q[0], q[1];
+c = measure q;
+"""
+
+    counts, message = backend.execute(program, shots=10)
+
+    assert message == "job is succeeded"
+    assert counts == {"00": 4, "11": 6}
+    delegated = backend._backend
+    delegated.validate.assert_called_once()
+    delegated.run.assert_called_once()
+    circuit = delegated.run.call_args.args[0]
+    assert isinstance(circuit, QuantumCircuit)
+    assert delegated.run.call_args.kwargs == {"memory": False, "shots": 10}
+    assert FakeProvider.last_kwargs == {"backend_cls": FakeBackendClass}
+
+
+def test_format_count_key_converts_hex_to_bitstring():
+    assert _format_count_key("0x3", 4) == "0011"
+    assert _format_count_key("0 1", 2) == "01"


### PR DESCRIPTION
## Summary
- add a generic qiskit_adapter backend plugin that delegates Device Gateway CallJob execution to configured Qiskit providers/backends
- add object loading helpers with class/class_ref/factory support for provider and backend configuration
- add example configs for qiskit-qubex-provider and qiskit-qm-provider integration

## Validation
- uv run pytest
- uv run ruff check src/device_gateway/core/object_loader.py src/device_gateway/plugins/qiskit_adapter/backend.py tests/device_gateway/plugins/qiskit_adapter/test_backend.py