### PR TITLE
feat: use gRPC message size limits from config

### DIFF
--- a/config/config.yaml.qubex
+++ b/config/config.yaml.qubex
@@ -1,7 +1,10 @@
 # gRPC settings
 proto:
-  max_workers: 2
-  address: "localhost:51021"
+  max_workers: ${GATEWAY_WORKERS, 10} # Maximum number of workers
+  address: ${GATEWAY_ADDRESS, "localhost:51021"} # Address and port for RPCs
+  grpc_options:
+    - ["grpc.max_receive_message_length", ${GRPC_MAX_RECEIVE_MESSAGE_LENGTH, 4194304}]
+    - ["grpc.max_send_message_length", ${GRPC_MAX_SEND_MESSAGE_LENGTH, 4194304}]
 
 # Common backend settings
 common_backend_settings: &common_backend_settings

--- a/config/config.yaml.qulacs
+++ b/config/config.yaml.qulacs
@@ -1,7 +1,10 @@
 # gRPC settings
 proto:
-  max_workers: 2
-  address: "localhost:51021"
+  max_workers: ${GATEWAY_WORKERS, 10} # Maximum number of workers
+  address: ${GATEWAY_ADDRESS, "localhost:51021"} # Address and port for RPCs
+  grpc_options:
+    - ["grpc.max_receive_message_length", ${GRPC_MAX_RECEIVE_MESSAGE_LENGTH, 4194304}]
+    - ["grpc.max_send_message_length", ${GRPC_MAX_SEND_MESSAGE_LENGTH, 4194304}]
 
 # Common backend settings
 common_backend_settings: &common_backend_settings

--- a/config/example/config.yaml
+++ b/config/example/config.yaml
@@ -1,7 +1,10 @@
 # gRPC settings
 proto:
-  max_workers: 2
-  address: "localhost:51021"
+  max_workers: ${GATEWAY_WORKERS, 10} # Maximum number of workers
+  address: ${GATEWAY_ADDRESS, "localhost:51021"} # Address and port for RPCs
+  grpc_options:
+    - ["grpc.max_receive_message_length", ${GRPC_MAX_RECEIVE_MESSAGE_LENGTH, 4194304}]
+    - ["grpc.max_send_message_length", ${GRPC_MAX_SEND_MESSAGE_LENGTH, 4194304}]
 
 # Common backend settings
 common_backend_settings: &common_backend_settings

--- a/src/device_gateway/service.py
+++ b/src/device_gateway/service.py
@@ -211,7 +211,10 @@ def serve(config_yaml_path: str, logging_yaml_path: str):
 
     max_workers = config_yaml["proto"].get("max_workers", 10)
     address = config_yaml["proto"].get("address", "localhost:51021")
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=max_workers))
+    server = grpc.server(
+        futures.ThreadPoolExecutor(max_workers),
+        options=config_yaml["proto"].get("grpc_options", []),
+    )
     qpu_pb2_grpc.add_QpuServiceServicer_to_server(
         ServerImpl(config=config_yaml), server
     )


### PR DESCRIPTION
This pull request updates the gRPC configuration for the service, making it more flexible and production-ready by allowing key parameters to be set via environment variables and supporting advanced gRPC options. The code now also passes these options to the gRPC server at runtime.

Configuration improvements:

* Added support for environment variable overrides for `max_workers` and `address` in the `proto` section of `config.yaml` files, making deployment and scaling easier. [[1]](diffhunk://#diff-5684f9f882ba4700a44a1f07beee352153ff112caf2486d6245e0405130bf1d1L3-R7) [[2]](diffhunk://#diff-406447b9a34dfe1fe37f7f9a293fb60314aa3970d30cfa65f8073cca560cf346L3-R7)
* Introduced a new `grpc_options` field in the `proto` configuration to allow setting `grpc.max_receive_message_length` and `grpc.max_send_message_length`, improving support for large message payloads. [[1]](diffhunk://#diff-5684f9f882ba4700a44a1f07beee352153ff112caf2486d6245e0405130bf1d1L3-R7) [[2]](diffhunk://#diff-406447b9a34dfe1fe37f7f9a293fb60314aa3970d30cfa65f8073cca560cf346L3-R7)

Server initialization changes:

* Updated `src/device_gateway/service.py` to pass the `grpc_options` from configuration to the gRPC server, enabling the new options at runtime.