### PR TITLE
chore: Make RPC settings configurable by environment settings

### DIFF
--- a/config/config.yaml.qubex
+++ b/config/config.yaml.qubex
@@ -1,7 +1,7 @@
 # gRPC settings
 proto:
-  max_workers: 2
-  address: "localhost:51021"
+  max_workers: ${GATEWAY_WORKERS, 2} # Maximum number of workers
+  address: ${GATEWAY_ADDRESS, "localhost:51012"} # Address and port for RPCs
 
 # Common backend settings
 common_backend_settings: &common_backend_settings

--- a/config/config.yaml.qulacs
+++ b/config/config.yaml.qulacs
@@ -1,7 +1,7 @@
 # gRPC settings
 proto:
-  max_workers: 2
-  address: "localhost:51021"
+  max_workers: ${GATEWAY_WORKERS, 2} # Maximum number of workers
+  address: ${GATEWAY_ADDRESS, "localhost:51012"} # Address and port for RPCs
 
 # Common backend settings
 common_backend_settings: &common_backend_settings

--- a/config/example/config.yaml
+++ b/config/example/config.yaml
@@ -1,7 +1,7 @@
 # gRPC settings
 proto:
-  max_workers: 2
-  address: "localhost:51021"
+  max_workers: ${GATEWAY_WORKERS, 2} # Maximum number of workers
+  address: ${GATEWAY_ADDRESS, "localhost:51012"} # Address and port for RPCs
 
 # Common backend settings
 common_backend_settings: &common_backend_settings


### PR DESCRIPTION
This pull request updates the gRPC configuration in several YAML files to support environment variable overrides for key settings. The main changes allow the `max_workers` and `address` parameters to be set via environment variables, making deployment and configuration more flexible.

Configuration improvements:

* Updated `proto.max_workers` and `proto.address` in `config/config.yaml.qubex`, `config/config.yaml.qulacs`, and `config/example/config.yaml` to use environment variables (`GATEWAY_WORKERS` and `GATEWAY_ADDRESS`) with sensible defaults, allowing these settings to be customized without editing the files directly. [[1]](diffhunk://#diff-5684f9f882ba4700a44a1f07beee352153ff112caf2486d6245e0405130bf1d1L3-R4) [[2]](diffhunk://#diff-406447b9a34dfe1fe37f7f9a293fb60314aa3970d30cfa65f8073cca560cf346L3-R4)