### PR TITLE
refactor: use module-based logger names

### DIFF
--- a/src/device_gateway/core/base_backend.py
+++ b/src/device_gateway/core/base_backend.py
@@ -2,7 +2,7 @@ import json
 import logging
 from abc import ABCMeta, abstractmethod
 
-logger = logging.getLogger("device_gateway")
+logger = logging.getLogger(__name__)
 
 # Constants
 SUCCESS_MESSAGE = "job is succeeded"

--- a/src/device_gateway/plugins/qubex/backend.py
+++ b/src/device_gateway/plugins/qubex/backend.py
@@ -11,7 +11,7 @@ from qubex.version import get_version
 from device_gateway.core.base_backend import SUCCESS_MESSAGE, BaseBackend
 from device_gateway.plugins.qubex.compiler import QubexCompiler
 
-logger = logging.getLogger("device_gateway")
+logger = logging.getLogger(__name__)
 
 
 class QubexBackend(BaseBackend):

--- a/src/device_gateway/plugins/qubex/compiler.py
+++ b/src/device_gateway/plugins/qubex/compiler.py
@@ -7,7 +7,7 @@ from qubex.pulse import Blank, PulseSchedule, VirtualZ
 if TYPE_CHECKING:
     from device_gateway.plugins.qubex.backend import QubexBackend
 
-logger = logging.getLogger("device_gateway")
+logger = logging.getLogger(__name__)
 
 # Qubex only ever drives pulses for this fixed native gate set, so unlike Qulacs
 # it is not configurable via supported_gates in config.yaml.

--- a/src/device_gateway/plugins/qulacs/backend.py
+++ b/src/device_gateway/plugins/qulacs/backend.py
@@ -8,7 +8,7 @@ from qulacs import QuantumState
 from device_gateway.core.base_backend import SUCCESS_MESSAGE, BaseBackend
 from device_gateway.plugins.qulacs.compiler import QulacsCompiler
 
-logger = logging.getLogger("device_gateway")
+logger = logging.getLogger(__name__)
 
 
 class QulacsBackend(BaseBackend):

--- a/src/device_gateway/plugins/qulacs/compiler.py
+++ b/src/device_gateway/plugins/qulacs/compiler.py
@@ -7,7 +7,7 @@ from qulacs import QuantumCircuit as QulacsQuantumCircuit
 if TYPE_CHECKING:
     from device_gateway.plugins.qulacs.backend import QulacsBackend
 
-logger = logging.getLogger("device_gateway")
+logger = logging.getLogger(__name__)
 
 # Single-qubit gates with no parameters: Qiskit instruction name -> QulacsQuantumCircuit method name
 _SINGLE_QUBIT_GATES = {


### PR DESCRIPTION
This pull request standardizes logging across the codebase by updating logger initialization to use the module's `__name__` instead of the fixed string `"device_gateway"`. This change improves log traceability by ensuring that log messages are associated with their actual module of origin.

**Logging improvements:**

* Updated logger initialization in `src/device_gateway/core/base_backend.py` to use `logging.getLogger(__name__)` for more accurate module-level logging.
* Updated logger initialization in `src/device_gateway/plugins/qubex/backend.py` to use `logging.getLogger(__name__)`.
* Updated logger initialization in `src/device_gateway/plugins/qubex/compiler.py` to use `logging.getLogger(__name__)`.
* Updated logger initialization in `src/device_gateway/plugins/qulacs/backend.py` to use `logging.getLogger(__name__)`.
* Updated logger initialization in `src/device_gateway/plugins/qulacs/compiler.py` to use `logging.getLogger(__name__)`.