### PR TITLE
fix: update Qubex measurement configuration

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -28,6 +28,8 @@ services:
       - CONFIG_DIR=/app/qubex_config
       - PARAMS_DIR=/app/qubex_config
       - CALIB_NOTE_PATH=/app/qubex_config/calib_note.json
+      - CONFIGURATION_MODE=${CONFIGURATION_MODE:-ge-cr-cr}
+      - SHOT_INTERVAL=${SHOT_INTERVAL:-307200}
     ports:
       - "51021:51021"
     restart: unless-stopped

--- a/config/config.yaml.qubex
+++ b/config/config.yaml.qubex
@@ -40,3 +40,5 @@ backend_di_container:
         config_dir: ${CONFIG_DIR, "/app/qubex-config/{chip_id}/config"}
         params_dir: ${PARAMS_DIR, "/app/qubex-config/{chip_id}/params"}
         calib_note_path: ${CALIB_NOTE_PATH, "/app/qubex-config/{chip_id}/calibration/calib_note.json"}
+        configuration_mode: ${CONFIGURATION_MODE, "ge-cr-cr"}  # Options: "ge-cr-cr", "ge-ef-cr"
+        shot_interval: ${SHOT_INTERVAL, 307200}  # Interval between shots in ns

--- a/config/config.yaml.qulacs
+++ b/config/config.yaml.qulacs
@@ -40,3 +40,5 @@ backend_di_container:
         config_dir: ${CONFIG_DIR, "/app/qubex-config/{chip_id}/config"}
         params_dir: ${PARAMS_DIR, "/app/qubex-config/{chip_id}/params"}
         calib_note_path: ${CALIB_NOTE_PATH, "/app/qubex-config/{chip_id}/calibration/calib_note.json"}
+        configuration_mode: ${CONFIGURATION_MODE, "ge-cr-cr"}  # Options: "ge-cr-cr", "ge-ef-cr"
+        shot_interval: ${SHOT_INTERVAL, 307200}  # Interval between shots in ns

--- a/config/example/config.yaml
+++ b/config/example/config.yaml
@@ -40,3 +40,5 @@ backend_di_container:
         config_dir: ${CONFIG_DIR, "/app/qubex-config/{chip_id}/config"}
         params_dir: ${PARAMS_DIR, "/app/qubex-config/{chip_id}/params"}
         calib_note_path: ${CALIB_NOTE_PATH, "/app/qubex-config/{chip_id}/calibration/calib_note.json"}
+        configuration_mode: ${CONFIGURATION_MODE, "ge-cr-cr"}  # Options: "ge-cr-cr", "ge-ef-cr"
+        shot_interval: ${SHOT_INTERVAL, 307200}  # Interval between shots in ns

--- a/docs/developer_guidelines/getting_started.md
+++ b/docs/developer_guidelines/getting_started.md
@@ -259,6 +259,8 @@ backend_di_container:
         config_dir: ${CONFIG_DIR, "/app/qubex-config/{chip_id}/config"}
         params_dir: ${PARAMS_DIR, "/app/qubex-config/{chip_id}/params"}
         calib_note_path: ${CALIB_NOTE_PATH, "/app/qubex-config/{chip_id}/calibration/calib_note.json"}
+        configuration_mode: ${CONFIGURATION_MODE, "ge-cr-cr"}  # Options: "ge-cr-cr", "ge-ef-cr"
+        shot_interval: ${SHOT_INTERVAL, 307200}  # Interval between shots in ns
 ```
 
 ### QPU Example
@@ -303,4 +305,11 @@ backend_di_container:
         config_dir: ${CONFIG_DIR, "/app/qubex-config/{chip_id}/config"}
         params_dir: ${PARAMS_DIR, "/app/qubex-config/{chip_id}/params"}
         calib_note_path: ${CALIB_NOTE_PATH, "/app/qubex-config/{chip_id}/calibration/calib_note.json"}
+        configuration_mode: ${CONFIGURATION_MODE, "ge-cr-cr"}  # Options: "ge-cr-cr", "ge-ef-cr"
+        shot_interval: ${SHOT_INTERVAL, 307200}  # Interval between shots in ns
 ```
+
+`configuration_mode` selects the Qubex pulse configuration (`ge-cr-cr` or
+`ge-ef-cr`). `shot_interval` sets the interval between shots in nanoseconds.
+Both settings can be overridden with the `CONFIGURATION_MODE` and
+`SHOT_INTERVAL` environment variables.

--- a/src/device_gateway/plugins/qubex/backend.py
+++ b/src/device_gateway/plugins/qubex/backend.py
@@ -4,7 +4,7 @@ import numpy as np
 from qiskit.qasm3 import loads
 from qiskit.result import Counts, LocalReadoutMitigator, ProbDistribution
 from qubex.experiment import Experiment
-from qubex.measurement.measurement_defaults import DEFAULT_INTERVAL, DEFAULT_SHOTS
+from qubex.measurement.measurement_defaults import DEFAULT_SHOTS
 from qubex.pulse import PulseSchedule
 from qubex.version import get_version
 
@@ -23,6 +23,7 @@ class QubexBackend(BaseBackend):
         config_dir = plugin_config["config_dir"].format_map(context)
         params_dir = plugin_config["params_dir"].format_map(context)
         calib_note_path = plugin_config["calib_note_path"].format_map(context)
+        self._shot_interval = plugin_config["shot_interval"]
         self._execute_readout_calibration = True
         self.classical_registers: list[str] = []
         self._experiment = Experiment(
@@ -31,9 +32,9 @@ class QubexBackend(BaseBackend):
             config_dir=config_dir,
             params_dir=params_dir,
             calib_note_path=calib_note_path,
+            configuration_mode=plugin_config["configuration_mode"],
         )
         self._compiler = QubexCompiler(self)
-        logger.info(f"Qubex version: {get_version()}")
 
     @property
     def physical_map(self):
@@ -71,7 +72,9 @@ class QubexBackend(BaseBackend):
         note = {}
         for qubit in self.qubits:
             logger.info(f"Building classifier for qubit {qubit}")
-            res = self._experiment.build_classifier(targets=qubit, plot=False)
+            res = self._experiment.build_classifier(
+                targets=qubit, plot=False, shot_interval=self._shot_interval
+            )
             note[qubit] = {
                 "p0m1": 1 - res["readout_fidelities"][qubit][0],
                 "p1m0": 1 - res["readout_fidelities"][qubit][1],
@@ -117,8 +120,8 @@ class QubexBackend(BaseBackend):
         return self._experiment.measure(
             circuit,
             mode="single",
-            shots=shots,
-            interval=DEFAULT_INTERVAL,
+            n_shots=shots,
+            shot_interval=self._shot_interval,
             reset_awg_and_capunits=True,
         ).get_counts(targets=self.classical_registers)
 

--- a/src/device_gateway/plugins/qubex/backend.py
+++ b/src/device_gateway/plugins/qubex/backend.py
@@ -23,7 +23,9 @@ class QubexBackend(BaseBackend):
         config_dir = plugin_config["config_dir"].format_map(context)
         params_dir = plugin_config["params_dir"].format_map(context)
         calib_note_path = plugin_config["calib_note_path"].format_map(context)
-        self._shot_interval = plugin_config["shot_interval"]
+        configuration_mode = plugin_config["configuration_mode"]
+        shot_interval = plugin_config["shot_interval"]
+        self._shot_interval = shot_interval
         self._execute_readout_calibration = True
         self.classical_registers: list[str] = []
         self._experiment = Experiment(
@@ -32,7 +34,7 @@ class QubexBackend(BaseBackend):
             config_dir=config_dir,
             params_dir=params_dir,
             calib_note_path=calib_note_path,
-            configuration_mode=plugin_config["configuration_mode"],
+            configuration_mode=configuration_mode,
         )
         self._compiler = QubexCompiler(self)
 

--- a/tests/device_gateway/plugins/test_qubex_backend.py
+++ b/tests/device_gateway/plugins/test_qubex_backend.py
@@ -1,0 +1,70 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("qubex.experiment")
+
+from device_gateway.plugins.qubex.backend import QubexBackend
+
+
+def make_topology():
+    return {
+        "qubits": [{"id": 0, "physical_id": 0}],
+        "couplings": [],
+    }
+
+
+def make_plugin_config():
+    return {
+        "chip_id": "test-chip",
+        "config_dir": "/config/{chip_id}",
+        "params_dir": "/params/{chip_id}",
+        "calib_note_path": "/calibration/{chip_id}/calib_note.json",
+        "configuration_mode": "ge-ef-cr",
+        "shot_interval": 123456,
+    }
+
+
+class TestQubexBackend:
+    def test_passes_new_settings_to_qubex(self, mocker):
+        mocker.patch(
+            "device_gateway.core.base_backend.BaseBackend.load_device_topology",
+            return_value=make_topology(),
+        )
+        experiment = mocker.patch("device_gateway.plugins.qubex.backend.Experiment")
+
+        QubexBackend("QPU", {}, make_plugin_config())
+
+        experiment.assert_called_once_with(
+            chip_id="test-chip",
+            qubits=[0],
+            config_dir="/config/test-chip",
+            params_dir="/params/test-chip",
+            calib_note_path="/calibration/test-chip/calib_note.json",
+            configuration_mode="ge-ef-cr",
+        )
+
+    def test_execute_uses_n_shots_and_configured_shot_interval(self, mocker):
+        mocker.patch(
+            "device_gateway.core.base_backend.BaseBackend.load_device_topology",
+            return_value=make_topology(),
+        )
+        experiment_class = mocker.patch(
+            "device_gateway.plugins.qubex.backend.Experiment"
+        )
+        experiment = experiment_class.return_value
+        experiment.measure.return_value.get_counts.return_value = {"0": 10}
+        backend = QubexBackend("QPU", {}, make_plugin_config())
+        schedule = MagicMock()
+
+        counts = backend._execute(schedule, shots=10)
+
+        assert counts == {"0": 10}
+        experiment.measure.assert_called_once_with(
+            schedule,
+            mode="single",
+            n_shots=10,
+            shot_interval=123456,
+            reset_awg_and_capunits=True,
+        )
+        experiment.measure.return_value.get_counts.assert_called_once_with(targets=[])


### PR DESCRIPTION
## Summary

- add configurable Qubex configuration mode and shot interval
- update measurement calls for the current Qubex API
- document the new settings and expose them in Docker Compose
- add regression tests for Qubex initialization and execution arguments

## Verification

- uv run pytest -q (42 passed)
- uv run ruff check
- uv run ruff format --check src tests
- uv run pymarkdownlnt scan docs/developer_guidelines/getting_started.md
- uv run mkdocs build --strict